### PR TITLE
Update build for more explicit find.exe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 642fb016bfe4bb7539ba6bf4e6dd5a95d2d25638387040b0f5eefdb84a840297
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .  --verbose
   skip: True  # [py<35]
 

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,7 +3,7 @@
 @REM There is some ability to run 32-bit and 64-bit applications on Windows. If the
 @REM default subdir is 32-bit, we do not want to show this message (as there is no oneDAL).
 @REM So, if the conda subdir is not win-64 -> exit.
-conda config --show subdir | find /I "win-64"
+conda config --show subdir | %SYSTEMROOT%\System32\find.exe /I "win-64"
 if errorlevel 1 exit 1
 
 (


### PR DESCRIPTION
Resolves #5 

Using explicit path to `find.exe` to alleviate issue with bash execution (Git Bash).

Using Git Bash I am able to replicate the issue in the prior build. With these changes the package installation no longer causes an error under those situations.