### PR TITLE
Update to v1.0.1

### DIFF
--- a/=1.1.0
+++ b/=1.1.0
@@ -1,0 +1,5 @@
+Loading channels: ...working... done
+# Name                       Version           Build  Channel             
+scipy                          1.7.1  py38h2f0f56f_2  pkgs/main           
+scipy                          1.7.1  py39h2f0f56f_1  pkgs/main           
+scipy                          1.7.1  py39h2f0f56f_2  pkgs/main           

--- a/=1.1.0
+++ b/=1.1.0
@@ -1,5 +1,0 @@
-Loading channels: ...working... done
-# Name                       Version           Build  Channel             
-scipy                          1.7.1  py38h2f0f56f_2  pkgs/main           
-scipy                          1.7.1  py39h2f0f56f_1  pkgs/main           
-scipy                          1.7.1  py39h2f0f56f_2  pkgs/main           

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 # the channels to use when building/uploading for test
-channels: ['c3i_test2/label/sklearn-1.0_1']
+channels: ['c3i_test2']

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+# the channels to use when building/uploading for test
+channels: ['c3i_test2/label/sklearn-1.0_1']

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 # the channels to use when building/uploading for test
-channels: ['c3i_test2']
+# channels: ['c3i_test2']

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 # the channels to use when building/uploading for test
-# channels: ['c3i_test2']
+channels: []

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: scikit-learn
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: fa478eaeb5dd92d0ac32f84e26b0de9dcfc52a64210887e4805a292927cc7102
+  sha256: 1b4d6b023baaf20b4d1b70ed67033182089c03995dc7ae0e803645fa9ed024f9
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,14 @@ requirements:
     - llvm-openmp  # [osx]
     - cython >=0.28.5
     - numpy
-    - scipy >=0.19.1
+    - scipy >=1.1.0
     - joblib >=0.11
     - threadpoolctl >=2.0.0
   run:
     - python
     - llvm-openmp  # [osx]
     - {{ pin_compatible('numpy') }}
-    - scipy >=0.19.1
+    - scipy >=1.1.0
     - joblib >=0.11
     - threadpoolctl >=2.0.0
     # Using selector until packages for other platforms are (re)built using
@@ -66,7 +66,10 @@ about:
   home: http://scikit-learn.org/
   license: BSD-3-Clause
   license_file: COPYING
+  license_family: BSD
   summary: A set of python modules for machine learning and data mining
+  doc_url: https://scikit-learn.org/dev/user_guide.html
+  dev_url: https://github.com/scikit-learn/scikit-learn
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.24.2" %}
+{% set version = "1.0" %}
 
 package:
   name: scikit-learn
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: 642fb016bfe4bb7539ba6bf4e6dd5a95d2d25638387040b0f5eefdb84a840297
+  sha256: fa478eaeb5dd92d0ac32f84e26b0de9dcfc52a64210887e4805a292927cc7102
 
 build:
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .  --verbose
-  skip: True  # [py<35]
+  skip: true  # [py<37]
 
 requirements:
   build:
@@ -36,8 +36,7 @@ requirements:
     - threadpoolctl >=2.0.0
     # Using selector until packages for other platforms are (re)built using
     # newer defaults toolchains that use the `_openmp_mutex` mechanism.
-    - _openmp_mutex   # [s390x]
-
+    - _openmp_mutex   # [linux and (not ppc64le)]
 
 # Some tests take alot of memory, and seem to cause segfaults when memory runs out
 {% set test_cpus = 1 %}
@@ -45,19 +44,10 @@ requirements:
 {% set tests_to_skip = "_not_a_real_test" %}
 # Can fail on aarch64 -- https://github.com/scikit-learn/scikit-learn/issues/15821
 {% set tests_to_skip = tests_to_skip + " or test_uniform_grid" %}                         # [aarch64]
-# Can fail -- https://github.com/scikit-learn/scikit-learn/issues/15818
-{% set tests_to_skip = tests_to_skip + " or test_sag_regressor_computed_correct" %}       # [linux]
-# Occasionally fails on aarch64 -- https://github.com/scikit-learn/scikit-learn/issues/15825
-{% set tests_to_skip = tests_to_skip + " or test_unreachable_accuracy" %}                 # [aarch64]
-# Fails on linux-aarch64
-{% set tests_to_skip = tests_to_skip + " or test_np_matrix" %}                  # [linux and aarch64]
-{% set tests_to_skip = tests_to_skip + " or test_lle_simple_grid" %}            # [linux and aarch64]
-# skip network tests -- https://github.com/scikit-learn/scikit-learn/issues/16743
-{% set tests_to_skip = tests_to_skip + " or network" %}
-{% set tests_to_skip = tests_to_skip + " or test_california_housing" %}
-# ppc64le failing test
-{% set tests_to_skip = tests_to_skip + " or test_k_means" %}  # [ppc64le]
-{% set tests_to_skip = tests_to_skip + " or test_mlp_regressor_dtypes_casting" %}  # [ppc64le]
+# https://github.com/scikit-learn/scikit-learn/issues/20335
+{% set tests_to_skip = tests_to_skip + " or test_loadings_converges" %}
+# Numerically unstable test numerical difference in test
+{% set tests_to_skip = tests_to_skip + " or test_mlp_regressor_dtypes_casting" %}         # [ppc64le]
 
 test:
   requires:
@@ -88,7 +78,8 @@ extra:
     - ogrisel
     - ocefpaf
     - lesteve
-    - msarahan
     - jnothman
     - rth
     - adrinjalali
+    - glemaitre
+    - jeremiedbb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     - llvm-openmp  # [osx]
     - cython >=0.28.5
     - numpy
@@ -49,7 +51,7 @@ requirements:
 
 test:
   requires:
-    - pytest >=3.3.0
+    - pytest >=5.0.1
     - cython >=0.28.5
     - pytest-xdist
     - pytest-timeout

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,6 @@ requirements:
 {% set test_cpus = 1 %}
 
 {% set tests_to_skip = "_not_a_real_test" %}
-# Can fail on aarch64 -- https://github.com/scikit-learn/scikit-learn/issues/15821
-{% set tests_to_skip = tests_to_skip + " or test_uniform_grid" %}                         # [aarch64]
 # https://github.com/scikit-learn/scikit-learn/issues/20335
 {% set tests_to_skip = tests_to_skip + " or test_loadings_converges" %}
 # Numerically unstable test numerical difference in test


### PR DESCRIPTION
First major release. 

Reviewed the [changelog](https://scikit-learn.org/dev/whats_new/v1.0.html#version-1-0-0).

Updated minimum dependencies ([source](https://scikit-learn.org/dev/whats_new/v1.0.html#minimal-dependencies)).

There are API changes in this release, so we may need to do some testing in `c3i_test2` before upload. According to Kai's `crender` tool, the following depend on `scikit-learn`:
```scikit-learn:
  ">=0.20.1":
    - dash-bio 0.2.0
  ">=0.18":
    - dask-glm 0.2.0
  ">=0.23.0":
    - dask-ml 1.9.0
  ">=0.18.0":
    - dask-searchcv 0.2.0
  "*":
    - esda 2.3.6
    - h2o-split 3.18.0.2
    - lightgbm 3.1.1
    - mapclassify 2.4.0
    - xgboost 0.90
    - pysal 2.1.0
    - segregation 1.2.0
    - xgboost-split 1.3.3
  ">=0.20":
    - fasttsne 0.2.13
    - opentsne 0.4.3
  ">=0.20.0":
    - orange3 3.23.1
  ">=0.19":
    - pynndescent 0.4.7```
