### PR TITLE
Do not error on non-Windows 64, simply exit.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 34471662f0e5ba8d2c799391338c6f976680cc66b715e00db0c7589f4f371bc4
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .  --verbose
   skip: true  # [py<37]
 

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -4,7 +4,7 @@
 @REM default subdir is 32-bit, we do not want to show this message (as there is no oneDAL).
 @REM So, if the conda subdir is not win-64 -> exit.
 conda config --show subdir | %SYSTEMROOT%\System32\find.exe /I "win-64"
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 0
 
 (
 echo.


### PR DESCRIPTION
fixes #12