### PR TITLE
Update to v1.1.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+# 7/14/2022: As of v1.1.0, scikit-learn requires minimum of numpy 1.17.3. 
+# See https://scikit-learn.org/dev/whats_new/v1.1.html#version-1-1-0
+numpy:
+  - 1.19.2

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,21 @@
 # 7/14/2022: As of v1.1.0, scikit-learn requires minimum of numpy 1.17.3. 
 # See https://scikit-learn.org/dev/whats_new/v1.1.html#version-1-1-0
 numpy:
-  - 1.19.2
+  # python 3.7-3.9
+  - 1.19    # [not (osx and arm64)]
+  - 1.19    # [not (osx and arm64)]
+  - 1.19    # [not (osx and arm64)]
+  # python 3.8-3.9
+  - 1.19    # [osx and arm64]
+  - 1.19    # [osx and arm64]
+  # python 3.10
+  - 1.21
+python:
+  - 3.7      # [not arm64]
+  - 3.8
+  - 3.9
+  - 3.10
+zip_keys:
+  -
+    - python
+    - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.1.1" %}
 
 package:
   name: scikit-learn
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: 34471662f0e5ba8d2c799391338c6f976680cc66b715e00db0c7589f4f371bc4
+  sha256: 568e621b9e1479b9ab952a9241db5af2ba3ab4f69d44b8aba3dd7648825e8e5a
 
 build:
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .  --verbose
-  skip: true  # [py<37]
+  skip: true  # [py<38]
 
 requirements:
   build:
@@ -21,20 +21,20 @@ requirements:
   host:
     - python
     - cython >=0.29.24
-    - joblib >=0.11
+    - joblib >=1.0.0
     - llvm-openmp  # [osx]
     - numpy
     - pip
-    - scipy >=1.1.0
+    - scipy >=1.3.2
     - setuptools <60.0
     - threadpoolctl >=2.0.0
     - wheel
   run:
     - python
-    - joblib >=0.11
+    - joblib >=1.0.0
     - llvm-openmp  # [osx]
     - {{ pin_compatible('numpy') }}
-    - scipy >=1.1.0
+    - scipy >=1.3.2
     - threadpoolctl >=2.0.0
     # Using selector until packages for other platforms are (re)built using
     # newer defaults toolchains that use the `_openmp_mutex` mechanism.
@@ -48,14 +48,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_loadings_converges" %}
 # Numerically unstable test numerical difference in test
 {% set tests_to_skip = tests_to_skip + " or test_mlp_regressor_dtypes_casting" %}         # [ppc64le]
-# On win32 there are failed tests:
-{% set tests_to_skip = tests_to_skip + " or test_precomputed_nearest_neighbors_filtering" %}          # [win32]
-{% set tests_to_skip = tests_to_skip + " or test_pca_n_components_mostly_explained_variance_ratio" %} # [win32]
-{% set tests_to_skip = tests_to_skip + " or (GaussianProcessRegressor and check_supervised_y_2d)" %}  # [win32]
-{% set tests_to_skip = tests_to_skip + " or (GaussianProcessRegressor and check_fit_idempotent)" %}   # [win32]
-{% set tests_to_skip = tests_to_skip + " or (SpectralEmbedding and check_pipeline_consistency)" %}    # [win32]
-{% set tests_to_skip = tests_to_skip + " or (Nystroem and check_fit_idempotent)" %}                   # [win32]
-{% set tests_to_skip = tests_to_skip + " or (StackingClassifier)" %}                                  # [win32]
 
 test:
   requires:
@@ -75,7 +67,7 @@ test:
     - pytest --timeout 300 -n {{ test_cpus }} --verbose --pyargs sklearn -k "not ({{ tests_to_skip }})"
 
 about:
-  home: http://scikit-learn.org/
+  home: https://scikit-learn.org/
   license: BSD-3-Clause
   license_file: COPYING
   license_family: BSD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - scipy >=1.3.2
     - threadpoolctl >=2.0.0
-    # Using selector until packages for other platforms are (re)built using
-    # newer defaults toolchains that use the `_openmp_mutex` mechanism.
-    - _openmp_mutex   # [linux and (not ppc64le)]
+    - _openmp_mutex
 
 # Some tests take alot of memory, and seem to cause segfaults when memory runs out
 {% set test_cpus = 1 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - scipy >=1.3.2
     - threadpoolctl >=2.0.0
-    - _openmp_mutex
+    - _openmp_mutex  # [linux]
 
 # Some tests take alot of memory, and seem to cause segfaults when memory runs out
 {% set test_cpus = 1 %}


### PR DESCRIPTION
Notes:
- Skip builds for `python<3.8`; upstream project began support for only `py38` to `py310` starting in [version 1.1.0](https://github.com/scikit-learn/scikit-learn/releases/tag/1.1.0).
- Remove `tests_to_skip` lines for `win-32` (we no longer support for this platform).
- As of `v1.1.0`, `scikit-learn` requires minimum of `numpy-1.17.3`. See [changelog for v1.1.0](https://scikit-learn.org/dev/whats_new/v1.1.html#version-1-1-0).
- Changelog: https://scikit-learn.org/dev/whats_new/v1.1.html#version-1-1-1
- License: https://github.com/scikit-learn/scikit-learn/blob/1.1.1/COPYING
- Update/confirm version pinnings for:
    - [`joblib`](https://github.com/scikit-learn/scikit-learn/blob/4fa77dd5b4017cf3b515004e3e57669d67327f50/sklearn/_min_dependencies.py#L18)
    - [`numpy`](https://github.com/scikit-learn/scikit-learn/blob/4fa77dd5b4017cf3b515004e3e57669d67327f50/sklearn/_min_dependencies.py#L15)
    - [`scipy`](https://github.com/scikit-learn/scikit-learn/blob/4fa77dd5b4017cf3b515004e3e57669d67327f50/sklearn/_min_dependencies.py#L17)
    - [`setuptools`](https://github.com/scikit-learn/scikit-learn/blob/4fa77dd5b4017cf3b515004e3e57669d67327f50/sklearn/_min_dependencies.py#L17)
    - [`threadpoolctl`](https://github.com/scikit-learn/scikit-learn/blob/4fa77dd5b4017cf3b515004e3e57669d67327f50/sklearn/_min_dependencies.py#L19)
    - [`pytest`](https://github.com/scikit-learn/scikit-learn/blob/4fa77dd5b4017cf3b515004e3e57669d67327f50/sklearn/_min_dependencies.py#L20)