### PR TITLE
Update-1.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "1.1.2" %}
 
 package:
   name: scikit-learn
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: 568e621b9e1479b9ab952a9241db5af2ba3ab4f69d44b8aba3dd7648825e8e5a
+  sha256: 92f3ad28149996caa9fd6ff5f849e7312d9fdedabe73760309a0e8b35b161735
 
 build:
   number: 0


### PR DESCRIPTION
Changes:
- Set version to 1.1.2 - this brings better compatibility with newer scipy versions

Changelog: https://scikit-learn.org/dev/whats_new/v1.1.html#version-1-1-2
Changes to previous: https://github.com/scikit-learn/scikit-learn/compare/1.1.1...1.1.2
License: https://github.com/scikit-learn/scikit-learn/blob/1.1.2/COPYING
Dependencies: https://github.com/scikit-learn/scikit-learn/blob/1.1.2/sklearn/_min_dependencies.py