### PR TITLE
V1.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.2" %}
+{% set version = "1.1.3" %}
 
 package:
   name: scikit-learn
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: 92f3ad28149996caa9fd6ff5f849e7312d9fdedabe73760309a0e8b35b161735
+  sha256: b7c0a9fb8dfcefcfc7ef8fe02a064d194980251d57efaea972cb76005afb3c63
 
 build:
   number: 0
@@ -70,9 +70,15 @@ about:
   license: BSD-3-Clause
   license_file: COPYING
   license_family: BSD
+  license_url: https://github.com/scikit-learn/scikit-learn/blob/{{ version }}/COPYING
   summary: A set of python modules for machine learning and data mining
+  description: |
+    Scikit-learn is an open source machine learning library that supports supervised and unsupervised learning. 
+    It also provides various tools for model fitting, data preprocessing, model selection, model evaluation, 
+    and many other utilities.
   doc_url: https://scikit-learn.org/dev/user_guide.html
   dev_url: https://github.com/scikit-learn/scikit-learn
+  doc_source_url: https://github.com/scikit-learn/scikit-learn/blob/{{ version }}/README.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changes:
- Update to 1.1.3
- Update about section

We could do without 1.1.3 (the changes regarding windows do not affect us). But 1.1.2 is missing from default somehow.

https://scikit-learn.org/dev/whats_new/v1.1.html
https://github.com/scikit-learn/scikit-learn/compare/1.1.2...1.1.3