### PR TITLE
scikit-learn 1.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,6 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"
-  - "--error-overdepending"
+  - ""
 
 channels:
   - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-# the channels to use when building/uploading for test
-channels: []

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,6 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
-  - ""
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - ""
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+  - "--error-overdepending"
+
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"
-  - "--error-overdepending"
+  - ""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   host:
     - python
     - cython
-    - joblib
     - llvm-openmp    # [osx]
     - numpy   1.19   # [py<310]
     - numpy   1.21   # [py==310]
@@ -54,7 +53,6 @@ requirements:
 test:
   requires:
     - cython >=0.29.24
-    - llvm-openmp    # [osx]
     - pip
     - pytest >=5.3.1
     - pytest-timeout

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   skip: true  # [py<38]
   script: 
-    # build the C files in parallel.
-    - {{ PYTHON }} setup.py build_ext -j{{ CPU_COUNT }}
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed .  -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,41 @@
+{% set name = "scikit-learn" %}
 {% set version = "1.2.0" %}
 
 package:
-  name: scikit-learn
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
+  url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
   sha256: 84ad05fbb8529856645344a81b01a0bbff8818493535de08a5e85b2054adc31a
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .  --verbose
+  script: python -m pip install --no-deps --ignore-installed .  -vv
   skip: true  # [py<38]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - llvm-openmp  # [osx]
+    - llvm-openmp    # [osx]
   host:
     - python
-    - cython >=0.29.24
-    - joblib >=1.0.0
-    - llvm-openmp  # [osx]
-    - numpy   1.19  # [py==38 or py==39]
-    - numpy   1.21  # [py==310]
+    - cython
+    - joblib
+    - llvm-openmp    # [osx]
+    - numpy   1.19   # [py<310]
+    - numpy   1.21   # [py==310]
+    - numpy   1.23   # [py>=311]
     - pip
-    - scipy >=1.3.2
+    - scipy
     - setuptools <60.0
-    - threadpoolctl >=2.0.0
+    - threadpoolctl
     - wheel
   run:
     - python
-    - joblib >=1.0.0
-    - llvm-openmp  # [osx]
+    - joblib >=1.1.1
+    - llvm-openmp    # [osx]
     - {{ pin_compatible('numpy') }}
     - scipy >=1.3.2
     - threadpoolctl >=2.0.0
@@ -50,13 +52,25 @@ requirements:
 
 test:
   requires:
-    - pytest >=5.0.1
+    - pytest >=5.3.1
     - cython >=0.29.24
     - pytest-xdist
     - pytest-timeout
     - pip
   imports:
     - sklearn
+    - sklearn.cluster
+    - sklearn.datasets
+    - sklearn.decomposition
+    - sklearn.ensemble
+    - sklearn.feature_extraction
+    - sklearn.linear_model
+    - sklearn.manifold
+    - sklearn.metrics
+    - sklearn.neighbors
+    - sklearn.tree
+    - sklearn.utils
+    - sklearn.svm
   commands:
     - pip check
     - set OPENBLAS_NUM_THREADS=1          # [win]
@@ -70,7 +84,6 @@ about:
   license: BSD-3-Clause
   license_file: COPYING
   license_family: BSD
-  license_url: https://github.com/scikit-learn/scikit-learn/blob/{{ version }}/COPYING
   summary: A set of python modules for machine learning and data mining
   description: |
     Scikit-learn is an open source machine learning library that supports supervised and unsupervised learning. 
@@ -78,7 +91,6 @@ about:
     and many other utilities.
   doc_url: https://scikit-learn.org/dev/user_guide.html
   dev_url: https://github.com/scikit-learn/scikit-learn
-  doc_source_url: https://github.com/scikit-learn/scikit-learn/blob/{{ version }}/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,9 @@ build:
   skip: true  # [py<38]
   script: 
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv
-  ignore_run_exports:
-    - llvm-openmp  # [osx]
   missing_dso_whitelist:
     - '*/libc++.1.dylib'  # [osx]
-    - '*/libomp.dylib'    # [osx]
+    #- '*/libomp.dylib'    # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.3" %}
+{% set version = "1.2.0" %}
 
 package:
   name: scikit-learn
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/scikit-learn/scikit-learn/archive/{{ version }}.tar.gz
-  sha256: b7c0a9fb8dfcefcfc7ef8fe02a064d194980251d57efaea972cb76005afb3c63
+  sha256: 84ad05fbb8529856645344a81b01a0bbff8818493535de08a5e85b2054adc31a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,7 @@ build:
   number: 0
   skip: true  # [py<38]
   script: 
-    # build the C files in parallel. This helps beat the
-    # time limit consistently on drone.io
+    # build the C files in parallel.
     - {{ PYTHON }} setup.py build_ext -j{{ CPU_COUNT }}
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed .  -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv
   missing_dso_whitelist:
     - '*/libc++.1.dylib'  # [osx]
-    #- '*/libomp.dylib'    # [osx]
+    - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,12 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .  -vv
   skip: true  # [py<38]
+  script: 
+    # build the C files in parallel. This helps beat the
+    # time limit consistently on drone.io
+    - {{ PYTHON }} setup.py build_ext -j{{ CPU_COUNT }}
+    - {{ PYTHON }} -m pip install --no-deps --ignore-installed .  -vv
 
 requirements:
   build:
@@ -52,11 +56,12 @@ requirements:
 
 test:
   requires:
-    - pytest >=5.3.1
     - cython >=0.29.24
-    - pytest-xdist
-    - pytest-timeout
+    - llvm-openmp    # [osx]
     - pip
+    - pytest >=5.3.1
+    - pytest-timeout
+    - pytest-xdist
   imports:
     - sklearn
     - sklearn.cluster

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - llvm-openmp    # [osx]
     - numpy   1.19   # [py<310]
     - numpy   1.21   # [py==310]
-    - numpy   1.23   # [py>=311]
+    - numpy   1.22   # [py>=311]
     - pip
     - scipy
     - setuptools <60.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,12 @@ build:
   number: 0
   skip: true  # [py<38]
   script: 
-    - {{ PYTHON }} -m pip install --no-deps --ignore-installed .  -vv
+    - {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv
+  ignore_run_exports:
+    - llvm-openmp  # [osx]
+  missing_dso_whitelist:
+    - '*/libc++.1.dylib'  # [osx]
+    - '*/libomp.dylib'    # [osx]
 
 requirements:
   build:
@@ -35,7 +40,6 @@ requirements:
   run:
     - python
     - joblib >=1.1.1
-    - llvm-openmp    # [osx]
     - {{ pin_compatible('numpy') }}
     - scipy >=1.3.2
     - threadpoolctl >=2.0.0


### PR DESCRIPTION
**Jira ticket:** [PKG-887](https://anaconda.atlassian.net/browse/PKG-887) (scikit-learn-1.2.0)

**The upstream data:**
Github releases:  https://github.com/scikit-learn/scikit-learn/releases
Changelog: https://scikit-learn.org/stable/whats_new/v1.2.html
Upstream license: License file: https://github.com/scikit-learn/scikit-learn/blob/master/COPYING
[Diff between the latest and previous upstream releases](https://github.com/scikit-learn/scikit-learn/compare/1.1.3...1.2.0)
Requirements:
 * setup.py:  https://github.com/scikit-learn/scikit-learn/blob/1.2.0/setup.py
 * min_dependencies.py https://github.com/scikit-learn/scikit-learn/blob/1.2.0/sklearn/_min_dependencies.py
 * pyproject.toml:  https://github.com/scikit-learn/scikit-learn/blob/1.2.0/pyproject.toml

**_Actions:_**

- Add new jinja2 templates

- Fix a verbose flag in the `script`

- Remove pinnings from `host`

- Update `numpy` pinnings in `host`

- Update `run` pinnings

- Update `pytest` pinning in `test/requires`

- Add new modules to `test/imports`

- Remove `license_url` because `license_file` already exists

- Remove `doc_source_url` because `doc_url` already exists

- Disable the `build_parameters` in `abs.yaml` to prevent failing on `osx` platforms

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.2.0
 * Release on PyPi:
    * version: 1.2.0
    * date: 2022-12-08T14:12:26
* [PyPi history](https://pypi.org/project/scikit-learn/#history)
 * Popularity: 
    * 3 months downloads: 3146327.0
    * All time:  17745300 downloads -  scikit-learn  1.2.0  A set of python modules for machine learning and data mining  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/scikit-learn/scikit-learn/tree/1.2.0 exists
3. - [x] Check the pinnings
4. - [x] Changelog url error:
    https://github.com/scikit-learn/scikit-learn/tree/1.2.0
    200
5. - [x] Additional research
    https://github.com/scikit-learn/scikit-learn/issues   
6. - [x] `dev_url`:
    https://github.com/scikit-learn/scikit-learn    
7. - [x] `doc_url`:
    https://scikit-learn.org/dev/user_guide.html
8. - [x] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [x] Verify the test section
13. - [x] Verify if the package is `architecture specific`
14. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: COPYING is present
16. - [x] license_family BSD is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/scikit-learn-feedstock/recipe/meta.yaml
Dependencies: ['threadpoolctl >=2.0.0', 'scipy >=1.3.2', 'python', 'setuptools <60.0', 'cython >=0.29.24', 'wheel', 'pip', 'joblib >=1.0.0', 'numpy']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libgcc-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 20**


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/scikit-learn-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/scikit-learn-feedstock/tree/1.2.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/scikit-learn)
* [Diff between upstream and feature branch](https://github.com/conda-forge/scikit-learn-feedstock/compare/main...AnacondaRecipes:1.2.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/scikit-learn-feedstock/compare/master...AnacondaRecipes:1.2.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/scikit-learn-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.2.0 git@github.com:AnacondaRecipes/scikit-learn-feedstock.git
```
