### PR TITLE
1.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.2.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 84ad05fbb8529856645344a81b01a0bbff8818493535de08a5e85b2054adc31a
+  sha256: 50613365b0c118b07ad51902d46b9f7779b8f81ea932a205bd12e64b829eea9a
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,7 @@ requirements:
     - python
     - joblib >=1.1.1
     - {{ pin_compatible('numpy') }}
-    # https://github.com/scikit-learn/scikit-learn/issues/25403
-    - scipy >=1.3.2,<1.10.0
+    - scipy >=1.3.2
     - threadpoolctl >=2.0.0
     - _openmp_mutex  # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 50613365b0c118b07ad51902d46b9f7779b8f81ea932a205bd12e64b829eea9a
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<38]
   script: 
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   host:
     # Host dependencies are pinned to last build
     - python
-    - cython 0.29.32
+    - cython 0.29.33
     - llvm-openmp 14.0.6  # [osx]
     - numpy   1.19   # [py<310]
     - numpy   1.21   # [py==310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,10 @@ requirements:
     - llvm-openmp 14.0.6  # [osx]
     - numpy   1.19   # [py<310]
     - numpy   1.21   # [py==310]
-    - numpy   1.22   # [py>=311]
+    - numpy   1.23   # [py>=311]
     - pip
-    - scipy 1.9.3
+    - scipy 1.9.3   # [py<311]
+    - scipy 1.10.0  # [py>=311]
     - setuptools <60.0
     - threadpoolctl 2.2.0
     - wheel


### PR DESCRIPTION
# scikit-learn v1.2.1

upstream: https://github.com/scikit-learn/scikit-learn/tree/1.2.1
`pyproject.toml`: https://github.com/scikit-learn/scikit-learn/blob/1.2.1/pyproject.toml
license: https://github.com/scikit-learn/scikit-learn/blob/1.2.1/COPYING

## Changes
- Bump version and SHA
- Update required `cython` version from `pyproject.toml`
- Adjust scipy pinnings now that https://github.com/scikit-learn/scikit-learn/issues/25403 was fixed.

## Notes
- This is needed for Python 3.11 support on `linux-aarch64`
- `linux-64` and `osx-64` succeeded but had a separate Prefect issue 