### PR TITLE
scikit-learn 1.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.2.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 84ad05fbb8529856645344a81b01a0bbff8818493535de08a5e85b2054adc31a
+  sha256: 50613365b0c118b07ad51902d46b9f7779b8f81ea932a205bd12e64b829eea9a
 
 build:
   number: 1


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index c2e69d8..0ecbe2a 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.2.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 84ad05fbb8529856645344a81b01a0bbff8818493535de08a5e85b2054adc31a
+  sha256: 50613365b0c118b07ad51902d46b9f7779b8f81ea932a205bd12e64b829eea9a
 
 build:
   number: 1

```

**Jira ticket:** [PKG-1032
PKG-887

PKG-386
PKG-248
PKG-60](https://anaconda.atlassian.net/browse/PKG-1032
https://anaconda.atlassian.net/browse/PKG-887

https://anaconda.atlassian.net/browse/PKG-386
https://anaconda.atlassian.net/browse/PKG-248
https://anaconda.atlassian.net/browse/PKG-60) (scikit-learn
scikit-learn
scikit-learn (a wrapper of skl2onnx converter)

daal4py/scikit-learn-intelex
scikit-learn-1.2.1
1.2.0


2021.6
1.1.3)

**The upstream data:**
Github releases:  https://github.com/scikit-learn/scikit-learn/releases
[Diff between the latest and previous upstream releases](https://github.com/scikit-learn/scikit-learn/compare/1.2.0...1.2.1)
Requirements:
 * setup.cfg:  https://github.com/scikit-learn/scikit-learn/blob/1.2.1/setup.cfg
 * setup.py:  https://github.com/scikit-learn/scikit-learn/blob/1.2.1/setup.py
 * pyproject.toml:  https://github.com/scikit-learn/scikit-learn/blob/1.2.1/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.2.1
 * Release on PyPi:
    * version: 1.2.1
    * date: 2023-01-24T16:43:15
* [PyPi history](https://pypi.org/project/scikit-learn/#history)
 * Popularity: 
    * 3 months downloads: 2317183.0
    * All time:  18820303 downloads -  scikit-learn  1.2.1  A set of python modules for machine learning and data mining  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: COPYING is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/scikit-learn-feedstock/recipe/meta.yaml
Dependencies: ['scipy 1.9.3', 'cython 0.29.32', 'threadpoolctl 2.2.0', 'joblib >=1.1.1', 'scipy >=1.3.2,<1.10.0', 'setuptools <60.0', 'python', 'wheel', 'threadpoolctl >=2.0.0', 'numpy', 'pip']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.8:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.9:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h6a19e1b_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h21f52d0_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h09290a1_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h86744a3_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 20**


</details>

**Jira ticket:** [PKG-1032
PKG-887

PKG-386
PKG-248
PKG-60](https://anaconda.atlassian.net/browse/PKG-1032
https://anaconda.atlassian.net/browse/PKG-887

https://anaconda.atlassian.net/browse/PKG-386
https://anaconda.atlassian.net/browse/PKG-248
https://anaconda.atlassian.net/browse/PKG-60) (scikit-learn
scikit-learn
scikit-learn (a wrapper of skl2onnx converter)

daal4py/scikit-learn-intelex
scikit-learn-1.2.1
1.2.0


2021.6
1.1.3)

**The upstream data:**
Github releases:  https://github.com/scikit-learn/scikit-learn/releases
[Diff between the latest and previous upstream releases](https://github.com/scikit-learn/scikit-learn/compare/1.2.0...1.2.1)
Requirements:
 * setup.cfg:  https://github.com/scikit-learn/scikit-learn/blob/1.2.1/setup.cfg
 * setup.py:  https://github.com/scikit-learn/scikit-learn/blob/1.2.1/setup.py
 * pyproject.toml:  https://github.com/scikit-learn/scikit-learn/blob/1.2.1/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.2.1
 * Release on PyPi:
    * version: 1.2.1
    * date: 2023-01-24T16:43:15
* [PyPi history](https://pypi.org/project/scikit-learn/#history)
 * Popularity: 
    * 3 months downloads: 2317183.0
    * All time:  18820329 downloads -  scikit-learn  1.2.1  A set of python modules for machine learning and data mining  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: COPYING is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/scikit-learn-feedstock/recipe/meta.yaml
Dependencies: ['python', 'pip', 'joblib >=1.1.1', 'setuptools <60.0', 'threadpoolctl >=2.0.0', 'numpy', 'threadpoolctl 2.2.0', 'cython 0.29.32', 'scipy 1.9.3', 'scipy >=1.3.2,<1.10.0', 'wheel']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.8:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.9:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h6a19e1b_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h21f52d0_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h09290a1_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  Encountered problems while solving:
  - package scipy-1.9.3-py310h86744a3_0 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 20**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/scikit-learn-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/scikit-learn-feedstock/tree/1.2.1)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/scikit-learn)
* [Diff between upstream and feature branch](https://github.com/conda-forge/scikit-learn-feedstock/compare/main...AnacondaRecipes:1.2.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/scikit-learn-feedstock/compare/master...AnacondaRecipes:1.2.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/scikit-learn-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.2.1 git@github.com:AnacondaRecipes/scikit-learn-feedstock.git
```
