### PR TITLE
[PKG-1315] Upgrades to v1.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.2.1" %}
+{% set version = "1.2.2" %}
+{% set sha256 = "992694e21ce4285aab71b09939d3ed7e5ddb41b8803eb98e10aaba927b74bdf1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +8,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 50613365b0c118b07ad51902d46b9f7779b8f81ea932a205bd12e64b829eea9a
+  sha256: {{ sha256 }} 
 
 build:
   number: 0
@@ -34,7 +35,7 @@ requirements:
     - pip
     - scipy 1.9.3   # [py<311]
     - scipy 1.10.0  # [py>=311]
-    - setuptools <60.0
+    - setuptools
     - threadpoolctl 2.2.0
     - wheel
   run:


### PR DESCRIPTION
- Updates the feedstock to the latest scikit-learn version, v1.2.2
- Removes requirement on `setuptools` depdendency, as per this [upstream change](https://github.com/scikit-learn/scikit-learn/pull/25651)