### PR TITLE
PKG-1633 Update to 1.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.2.1" %}
+{% set version = "1.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 50613365b0c118b07ad51902d46b9f7779b8f81ea932a205bd12e64b829eea9a
+  sha256: 992694e21ce4285aab71b09939d3ed7e5ddb41b8803eb98e10aaba927b74bdf1
 
 build:
   number: 0
@@ -28,13 +28,12 @@ requirements:
     - python
     - cython 0.29.33
     - llvm-openmp 14.0.6  # [osx]
-    - numpy   1.19   # [py<310]
-    - numpy   1.21   # [py==310]
+    - numpy   1.21   # [py<311]
     - numpy   1.23   # [py>=311]
     - pip
     - scipy 1.9.3   # [py<311]
     - scipy 1.10.0  # [py>=311]
-    - setuptools <60.0
+    - setuptools
     - threadpoolctl 2.2.0
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }} 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   script: 
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,10 @@ requirements:
     - scipy >=1.3.2
     - threadpoolctl >=2.0.0
     - _openmp_mutex  # [linux]
+  run_constrained:
+    # intel-openmp 2023.1 and llvm-openmp 14.0.6 appear not be compatible
+    # leading to segfault in test_pairwise_distances_reduction.py::test_sqeuclidean_row_norms[42-float64-8-5-100]
+    - intel-openmp <2023.1  # [osx and x86_64]
 
 # Some tests take alot of memory, and seem to cause segfaults when memory runs out
 {% set test_cpus = 1 %}


### PR DESCRIPTION
Changes:
- increase build number of 1.2.2
- run_constrained for openmp issue on osx-64

https://github.com/scikit-learn/scikit-learn/tree/1.2.2
https://github.com/scikit-learn/scikit-learn/blob/1.2.2/pyproject.toml
https://github.com/scikit-learn/scikit-learn/blob/1.2.2/sklearn/_min_dependencies.py
https://github.com/scikit-learn/scikit-learn/blob/1.2.2/setup.py#L638