### PR TITLE
Version 1.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,17 @@ test:
     - pytest >=7.1.2
     - pytest-timeout
     - pytest-xdist
+    - matplotlib >=3.3.4
+    - scikit-image >=0.17.2
+    - pandas >=1.1.5
+    - pytest-cov >=2.9.0
+    - ruff >=0.0.272
+    - black >=23.3.0
+    - mypy >=1.3
+    - pyamg >=4.0.0
+    - pyarrow >=12.0.0
+    - numpydoc >=1.2.0
+    - pooch >=1.6.0
   imports:
     - sklearn
     - sklearn.cluster

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,15 +29,16 @@ requirements:
     - numpy {{ numpy }}
     - llvm-openmp 14.0.6  # [osx]
     - pip
-    - scipy >=1.6.0  # [not aarch64]
-    - scipy >=1.8  # [aarch64]
+    - scipy 1.9.3   # [py<311]
+    - scipy 1.10.0  # [py==311]
+    - scipy 1.11  # [py==312]
     - setuptools
     - wheel
     # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
     - blas=*=openblas  # [osx and x86_64]
   run:
     - python
-    - joblib >=1.1.1
+    - joblib >=1.2.0
     - {{ pin_compatible('numpy') }}
     # There is some problem on osx-64 when numpy 1.25 for python 3.11 is used - 48 tests fail badly.
     - numpy <1.25  # [osx-64 and py==311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,9 @@ requirements:
     - joblib >=1.2.0
     - {{ pin_compatible('numpy') }}
     - scipy >=1.6.0
+    # Build fails on osx-64 without the newest version of scipy.
+    # https://github.com/scikit-learn/scikit-learn/issues/28367#issuecomment-1941101095
+    - scipy 1.13.0  # [osx and x86_64]
     - threadpoolctl >=2.0.0
     - llvm-openmp  # [osx]
     - _openmp_mutex  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [win or linux or arm64 or py<39]
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:
@@ -41,7 +41,7 @@ requirements:
     - joblib >=1.1.1
     - {{ pin_compatible('numpy') }}
     # There is some problem on osx-64 when numpy 1.25 for python 3.11 is used - 48 tests fail badly.
-    - numpy <1.25  # [osx-64 and py==311]
+    # - numpy <1.25  # [osx-64 and py==311]
     - scipy >=1.6.0
     - threadpoolctl >=2.0.0
     - llvm-openmp  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx and x86_64]
   skip: true  # [py<39]
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
@@ -41,8 +40,6 @@ requirements:
     - python
     - joblib >=1.2.0
     - {{ pin_compatible('numpy') }}
-    # There is some problem on osx-64 when numpy 1.25 for python 3.11 is used - 48 tests fail badly.
-    - numpy <1.25  # [osx-64 and py==311]
     - scipy >=1.6.0
     - threadpoolctl >=2.0.0
     - llvm-openmp  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,7 @@ test:
     - ruff >=0.0.272
     - black >=23.3.0
     - mypy >=1.3
-    - pyamg >=4.0.0
+    - pyamg >=4.0.0  # [not s390x]
     - pyarrow >=12.0.0
     - numpydoc >=1.2.0
     - pooch >=1.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win or linux or arm64 or py<39]
+  skip: true  # [py<39]
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:
@@ -41,7 +41,7 @@ requirements:
     - joblib >=1.1.1
     - {{ pin_compatible('numpy') }}
     # There is some problem on osx-64 when numpy 1.25 for python 3.11 is used - 48 tests fail badly.
-    # - numpy <1.25  # [osx-64 and py==311]
+    - numpy <1.25  # [osx-64 and py==311]
     - scipy >=1.6.0
     - threadpoolctl >=2.0.0
     - llvm-openmp  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   host:
     # Host dependencies are pinned to last build
     - python
-    - cython 0.29
+    - cython 3.0.8
     - numpy {{ numpy }}
     - llvm-openmp 14.0.6  # [osx]
     - pip
@@ -62,7 +62,7 @@ requirements:
 
 test:
   requires:
-    - cython >=0.29.24
+    - cython >=3.0.8
     - pip
     - pytest >=7.1.2
     - pytest-timeout

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     # There is some problem on osx-64 when numpy 1.25 for python 3.11 is used - 48 tests fail badly.
     - numpy <1.25  # [osx-64 and py==311]
-    - scipy >=1.5.0
+    - scipy >=1.6.0
     - threadpoolctl >=2.0.0
     - llvm-openmp  # [osx]
     - _openmp_mutex  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,7 @@ requirements:
     - numpy {{ numpy }}
     - llvm-openmp 14.0.6  # [osx]
     - pip
-    - scipy 1.9.3   # [py<311]
-    - scipy 1.10.0  # [py==311]
-    - scipy 1.11  # [py==312]
+    - scipy >=1.6.0
     - setuptools
     - wheel
     # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.3.0" %}
+{% set version = "1.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "8be549886f5eda46436b6e555b0e4873b4f10aa21c07df45c4bc1735afbccd7a"
+  sha256: "daa1c471d95bad080c6e44b4946c9390a4842adc3082572c20e4f8884e39e959"
 
 build:
-  number: 2
-  skip: true  # [py<38]
-  script: 
+  number: 0
+  skip: true  # [py<39]
+  script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:
     - '*/libc++.1.dylib'  # [osx]
@@ -96,8 +96,8 @@ about:
   license_family: BSD
   summary: A set of python modules for machine learning and data mining
   description: |
-    Scikit-learn is an open source machine learning library that supports supervised and unsupervised learning. 
-    It also provides various tools for model fitting, data preprocessing, model selection, model evaluation, 
+    Scikit-learn is an open source machine learning library that supports supervised and unsupervised learning.
+    It also provides various tools for model fitting, data preprocessing, model selection, model evaluation,
     and many other utilities.
   doc_url: https://scikit-learn.org/dev/user_guide.html
   dev_url: https://github.com/scikit-learn/scikit-learn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [x86_64 or py<39]
+  skip: true  # [osx and x86_64]
+  skip: true  # [py<39]
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - scipy >=1.6.0
     # Build fails on osx-64 without the newest version of scipy.
     # https://github.com/scikit-learn/scikit-learn/issues/28367#issuecomment-1941101095
-    - scipy 1.13.0  # [osx and x86_64]
+    - scipy >=1.13.0  # [osx and x86_64]
     - threadpoolctl >=2.0.0
     - llvm-openmp  # [osx]
     - _openmp_mutex  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [linux or win or arm64 or py<39]
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:
@@ -29,9 +29,8 @@ requirements:
     - numpy {{ numpy }}
     - llvm-openmp 14.0.6  # [osx]
     - pip
-    - scipy 1.9.3   # [py<311]
-    - scipy 1.10.0  # [py==311]
-    - scipy 1.11  # [py==312]
+    - scipy >=1.6.0  # [not aarch64]
+    - scipy >=1.8  # [aarch64]
     - setuptools
     - wheel
     # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,14 +68,9 @@ test:
     - pytest >=7.1.2
     - pytest-timeout
     - pytest-xdist
-    - matplotlib >=3.3.4
+    - matplotlib-base >=3.3.4
     - scikit-image >=0.17.2
     - pandas >=1.1.5
-    - pytest-cov >=2.9.0
-    - ruff >=0.0.272
-    - black >=23.3.0
-    - mypy >=1.3
-    - pyamg >=4.0.0  # [not s390x]
     - pyarrow >=12.0.0
     - numpydoc >=1.2.0
     - pooch >=1.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [linux or win or arm64 or py<39]
+  skip: true  # [x86_64 or py<39]
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:


### PR DESCRIPTION
scikit-learn 1.4.2

**Destination channel:** defaults

### Links

- [PKG-3390](https://anaconda.atlassian.net/browse/PKG-3390)
- [Upstream repository](https://github.com/scikit-learn/scikit-learn/tree/1.4.2)
- [Upstream changelog/diff](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_4_0.html)

### Explanation of changes:
- Update version
- Dependency updates
- Add more testing
- Scipy pinning for osx-64 [issue](https://github.com/scikit-learn/scikit-learn/issues/28367#issuecomment-1941101095) 


[PKG-3390]: https://anaconda.atlassian.net/browse/PKG-3390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ