### PR TITLE
Update version to 1.7.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/scikit_learn-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
   sha256: 20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "scikit-learn" %}
-{% set version = "1.7.1" %}
-{% set sha256 = "24b3f1e976a4665aa74ee0fcaac2b8fccc6ae77c8e07ab25da3ba6d3292b9802" %}
+{% set version = "1.7.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/scikit_learn-{{ version }}.tar.gz
+  sha256: 20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda
 
 build:
   number: 0
@@ -21,6 +20,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -29,7 +29,7 @@ requirements:
     - cython >=3.0.10,<3.2.0
     - numpy {{ numpy }}
     - llvm-openmp 14.0.6  # [osx]
-    - scipy >=1.8.0,<1.16.0
+    - scipy >=1.8.0,<1.17.0
     - meson-python >=0.16.0,<0.19.0
     - python-build  # [win]
   run:


### PR DESCRIPTION
scikit-learn 1.7.2 

**Destination channel:** Defaults

### Links

- [PKG-9595](https://anaconda.atlassian.net/browse/PKG-9595)
- dev_url:        https://github.com/scikit-learn/scikit-learn/tree/1.7.2
- conda_forge:    https://github.com/conda-forge/scikit-learn-feedstock
- pypi:           https://pypi.org/project/scikit-learn/1.7.2
- pypi inspector: https://inspector.pypi.io/project/scikit-learn/1.7.2

### Explanation of changes:

- new version number

[PKG-9595]: https://anaconda.atlassian.net/browse/PKG-9595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ