### PR TITLE
scikit-learn 1.7.2: rebuild py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pythran-feedstock/pr14/3590247
-  - https://staging.continuum.io/pbp/fs/scikit-image-feedstock/pr25/6e868cd

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pythran-feedstock/pr14/1a9f2e1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
-extra_labels_for_os:
-  # We aren't strictly tied to ventura but we do get kernel panics on
-  # the builders if we're not.
-  osx-arm64: [ventura]
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,5 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 channels:
-  - https://staging.continuum.io/pbp/fs/pythran-feedstock/pr14/1a9f2e1
+  - https://staging.continuum.io/pbp/fs/pythran-feedstock/pr14/3590247
+  - https://staging.continuum.io/pbp/fs/scikit-image-feedstock/pr25/6e868cd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
   sha256: 20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
   missing_dso_whitelist:
-    - '*/libc++.1.dylib'  # [osx]
-    - '*/libomp.dylib'  # [osx]
-  skip: True  # [py<310]
+    - "*/libc++.1.dylib"  # [osx]
+    - "*/libomp.dylib"  # [osx]
+  skip: true  # [py<310]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,7 +91,8 @@ test:
     - pandas >=1.4.0
     # latest polars in main = 0.20.18
     #- polars >=0.20.23
-    - pyarrow >=12.0.0
+    # pyarrow is not available for python 3.14 on the main channel yet
+    - pyarrow >=12.0.0  # [py<314]
     # tests docstring failed with numpydoc >=1.9.0
     - numpydoc >=1.2.0,<1.9.0  # [py<313]
     - pooch >=1.6.0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-10984) 
- [Upstream repository](https://github.com/scikit-learn/scikit-learn/tree/1.7.2)

### Explanation of changes:

- Constrain pyarrow to py<314 because it's not available for python 3.14 on the main channel yet

### Notes:

- It requires the next rebuilds:
  -  https://github.com/AnacondaRecipes/pythran-feedstock/pull/14
  - https://github.com/AnacondaRecipes/scikit-image-feedstock/pull/25