### PR TITLE
Explicitly include openmp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+channels:
+  - build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler:
-  - vs2022                     # [win]
-cxx_compiler:
-  - vs2022                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,9 @@ source:
   sha256: 9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
-  missing_dso_whitelist:
-    - "*/libc++.1.dylib"  # [osx]
-    - "*/libomp.dylib"  # [osx]
   skip: true  # [py<311]
 
 requirements:
@@ -28,9 +25,12 @@ requirements:
     - python
     - cython >=3.1.2,<3.3.0
     - numpy {{ numpy }}
-    - llvm-openmp 14.0.6  # [osx]
+    - llvm-openmp {{ cxx_compiler_version }}  # [osx]
+    - libgomp  # [linux]
+    - vcomp14  # [win and x86_64]
     - scipy >=1.10.0,<1.17.0
     - meson-python >=0.17.1,<0.19.0
+    - ninja-base >=1.8.2
     - python-build  # [win]
   run:
     - python
@@ -39,7 +39,8 @@ requirements:
     - scipy >=1.10.0
     - threadpoolctl >=3.2.0
     - llvm-openmp  # [osx]
-    - _openmp_mutex  # [linux]
+    - libgomp  # [linux]
+    - vcomp14  # [win and x86_64]
 
 test:
   imports:


### PR DESCRIPTION
scikit-learn openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14736](https://anaconda.atlassian.net/browse/PKG-14736) 


### Explanation of changes:

- Delete un-needed cbc
- Bump build number
- Remove missing_dso_whitelist
- Explicitly pin the openmp_impl being used. 

## Note
Github UI didn't update the graph is green: https://package-build.anaconda.com/v1/graph/d1069bbc-f68c-49f1-a42b-7334f4125bf5

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)

[PKG-14736]: https://anaconda.atlassian.net/browse/PKG-14736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ